### PR TITLE
Fixes for *bs-no-admin* slab

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Set-Remote 'https://pave.eightsix.io/public/latest'
 Set local cache location
 
 ```pwsh
-Set-Remote '~/slabs'
+Set-Cache '~/slabs'
 ```
 
 Find available slabs
@@ -63,12 +63,17 @@ Find-Slab
 ```
 
 ```text
-bs
-bs-no-admin
-bs-pwsh
-bs-winget
-pwsh-profiles
-pwsh-scripts
+Name          Description                                                                  DependsOn
+----          -----------                                                                  ---------
+bs            Bootstrap a Windows development machine                                      {bs-no-admin, bs-pwsh, bs-winget, slab-u…
+bs-no-admin   Bootstrap a Windows dev machine without admin rights                         slab-utils
+bs-pwsh       Bootstrap pwsh settings                                                      {pwsh-profiles, pwsh-scripts, slab-utils}
+bs-winget     Bootstrap using winget (Windows Package Manager)                             slab-utils
+git-bash      Deploy a git-prompts shell script that hides the MINGW element in the prompt
+pwsh-profiles Deploys pwsh profiles and supporting scripts                                 slab-utils
+pwsh-scripts  deploys some pwsh scripts                                                    slab-utils
+reg-tweaks    Changes a variety of registry settings                                       slab-utils
+slab-utils    common utilities for slabs
 ```
 
 Install a slab
@@ -105,3 +110,11 @@ Deploy a slab - some slabs e.g. `pwsh-profiles` are designed to be deployed afte
 ```pwsh
 Deploy-Slab 'pwsh-profiles'
 ```
+
+or using the `lay` alias
+
+```pwsh
+lay 'pwsh-profiles'
+```
+
+

--- a/pwsh/pave.psm1
+++ b/pwsh/pave.psm1
@@ -125,7 +125,7 @@ function Find-Slab {
         $IndexUri = "$Script:Remote/slabs/~index"
         Write-Verbose "Getting index from $IndexUri"
         Start-BitsTransfer $IndexUri $TempFile.FullName
-        $Slabs = Get-Content -Raw $TempFile.FullName | ConvertFrom-Json -Depth 3 -AsHashtable
+        $Slabs = Get-Content -Raw $TempFile.FullName | ConvertFrom-Json -AsHashtable
     }
 
     process {

--- a/pwsh/pave.psm1
+++ b/pwsh/pave.psm1
@@ -125,7 +125,7 @@ function Find-Slab {
         $IndexUri = "$Script:Remote/slabs/~index"
         Write-Verbose "Getting index from $IndexUri"
         Start-BitsTransfer $IndexUri $TempFile.FullName
-        $Slabs = Get-Content -Raw $TempFile.FullName | ConvertFrom-Json -AsHashtable
+        $Slabs = Get-Content -Raw $TempFile.FullName | ConvertFrom-Json | Get-Member -Type NoteProperty | select -exp name
     }
 
     process {

--- a/slabs/bs-no-admin/lay.ps1
+++ b/slabs/bs-no-admin/lay.ps1
@@ -36,10 +36,10 @@ Write-Information "$LogMessage$LogDone"
         'ms-vscode.remote-repositories'
     )
     
-    & "$ScriptsFolder\Install-DotNetLts.ps1"
-    & "$ScriptsFolder\Install-GitForWindows.ps1" 
-    & "$ScriptsFolder\Install-BsCode.ps1" -BuildType $VsBuildType #-UsePSGallery #-VsCodeExtensions $VsCodeExtensions
-    & "$ScriptsFolder\Install-AzureDataStudio.ps1"
-    & "$ScriptsFolder\Install-StorageExplorer.ps1"
+    & ".\Scripts\Install-DotNetLts.ps1"
+    & ".\Scripts\Install-GitForWindows.ps1" 
+    & ".\Scripts\Install-BsCode.ps1" -BuildType $VsBuildType #-UsePSGallery #-VsCodeExtensions $VsCodeExtensions
+    & ".\Scripts\Install-AzureDataStudio.ps1"
+    & ".\Scripts\Install-StorageExplorer.ps1"
     
 } | & "$Env:LocalAppData\powershell\pwsh" -WorkingDirectory $PSScriptRoot -noexit  -command -


### PR DESCRIPTION
pave module:
- compatibility with PowerShell 5.1
  - remove unsupported params for calls to `ConvertFrom-Json`

bs-no-admin slab:
- fix path to scripts folder in `lay.ps1`